### PR TITLE
Feat/deadzone at center

### DIFF
--- a/cmd/hidi/hidi-config/factory/gamepad/PS4_Controller.toml
+++ b/cmd/hidi/hidi-config/factory/gamepad/PS4_Controller.toml
@@ -1,0 +1,58 @@
+collision_mode = "interrupt"
+exit_sequence = []
+
+[identifier] # marking config as default as zero-value identifier
+  bus = 0x00
+  vendor = 0x054c
+  product = 0x05c4
+  version = 0x00
+
+[defaults] # initial device state
+  octave = 0
+  semitone = 0
+  channel = 1
+  mapping = "Default"
+
+[action_mapping]
+  BTN_SELECT = "channel_down"
+  BTN_START = "channel_up"
+  BTN_MODE = "panic"
+  BTN_TL = "cc_learning"
+
+[deadzone]
+  default = 0.1
+  [deadzone.deadzones]
+    ABS_X = 0.1
+    ABS_Y = 0.1
+    ABS_RX = 0.1
+    ABS_RY = 0.1
+    ABS_Z = 0.0
+    ABS_RZ = 0.0
+    ABS_HAT0X = 0.0
+    ABS_HAT0Y = 0.0
+
+[[mapping]]
+  name = "Default"
+  [mapping.keys]
+    BTN_A = "0"
+    BTN_B = "1"
+    BTN_X = "2"
+    BTN_Y = "3"
+    BTN_C = "4"
+    BTN_Z = "6"
+    BTN_TL2 = "7"
+    BTN_TR2 = "8"
+    BTN_THUMBL = "9"
+    BTN_THUMBR = "10"
+    BTN_TL = "11"
+    BTN_TR = "12"
+
+  [mapping.analog]
+    ABS_X = { type = "cc", cc = 0, deadzone_at_center = true }
+    ABS_Y = { type = "pitch_bend", flip_axis = true, deadzone_at_center = true }
+    ABS_RX = { type = "cc", cc = 1, cc_negative = 2, deadzone_at_center = true }
+    ABS_RY = { type = "cc", cc = 3, cc_negative = 4, flip_axis = true, deadzone_at_center = true }
+    ABS_Z = { type = "cc", cc = 5 }
+    ABS_RZ = { type = "cc", cc = 6 }
+    ABS_HAT0X = { type = "action", action = "octave_up", action_negative = "octave_down" }
+    ABS_HAT0Y = { type = "action", action = "mapping_up", action_negative = "mapping_down", flip_axis = true }

--- a/cmd/hidi/hidi-config/user/README.md
+++ b/cmd/hidi/hidi-config/user/README.md
@@ -74,7 +74,7 @@ files.
     - `{type: pitch_bend}` - pitch-bend control
     - `{type: action, action: octave_up, action_negative: octave_down}` - self-explanatory (action emulation will be
       moved into `action_mapping` section in the future)
-    - for all these types there is optional `flip_axis: true` setting which inverts the interpretation of incoming values.
+    - for all these types there is optional `flip_axis: true` setting which inverts the interpretation of incoming values, and `deadzone_at_center: true` that sets the deadzone at the center of the range, instead of at zero.
 - `deadzones` - key:deadzone mapping in `0.0` - `1.0` range.
 - `default_deadzone` - default deadzone value for all other events  that were not specified in `deadzones` section
 

--- a/internal/pkg/midi/device/config/config.go
+++ b/internal/pkg/midi/device/config/config.go
@@ -113,6 +113,7 @@ type Analog struct {
 	Action, ActionNeg Action
 	FlipAxis          bool
 	Bidirectional     bool
+	DeadzoneAtCenter bool
 }
 
 type Key struct {

--- a/internal/pkg/midi/device/config/monitor.go
+++ b/internal/pkg/midi/device/config/monitor.go
@@ -42,7 +42,7 @@ func DetectDeviceConfigChanges(ctx context.Context) <-chan bool {
 			}
 
 			name := strings.ToLower(event.Name)
-			if strings.HasSuffix(name, "yml") || strings.HasSuffix(name, "yaml") {
+			if strings.HasSuffix(name, "yml") || strings.HasSuffix(name, "yaml") || strings.HasSuffix(name, "toml") {
 				log.Info(fmt.Sprintf("config change detected: %s", event.Name), logger.Info)
 				change <- true
 			}

--- a/internal/pkg/midi/device/config/parser.go
+++ b/internal/pkg/midi/device/config/parser.go
@@ -78,6 +78,7 @@ type TOMLDeviceConfig struct {
 			Action                *string `toml:"action,omitempty"`
 			ActionNegative        *string `toml:"action_negative,omitempty"`
 			FlipAxis              bool    `toml:"flip_axis"`
+			DeadzoneAtCenter bool  `toml:"deadzone_at_center,omitempty"`
 		} `toml:"analog,omitempty"`
 	} `toml:"mapping"`
 }
@@ -260,12 +261,14 @@ func ParseData(data []byte) (Config, error) {
 					ChannelOffsetNeg: byte(analog.ChannelOffsetNegative),
 					FlipAxis:         analog.FlipAxis,
 					Bidirectional:    bidirectional,
+					DeadzoneAtCenter: analog.DeadzoneAtCenter,
 				}
 			case AnalogPitchBend:
 				analogMapping[evcode] = Analog{
 					MappingType:   mappingType,
 					FlipAxis:      analog.FlipAxis,
 					ChannelOffset: byte(analog.ChannelOffset),
+					DeadzoneAtCenter: analog.DeadzoneAtCenter,
 				}
 			case AnalogActionSim:
 				var bidirectional bool
@@ -295,6 +298,7 @@ func ParseData(data []byte) (Config, error) {
 					ActionNeg:     actionNegative,
 					FlipAxis:      analog.FlipAxis,
 					Bidirectional: bidirectional,
+					DeadzoneAtCenter: analog.DeadzoneAtCenter,
 				}
 
 			case AnalogKeySim:
@@ -325,6 +329,7 @@ func ParseData(data []byte) (Config, error) {
 					NoteNeg:       noteNeg,
 					FlipAxis:      analog.FlipAxis,
 					Bidirectional: bidirectional,
+					DeadzoneAtCenter: analog.DeadzoneAtCenter,
 				}
 			default:
 				return Config{}, fmt.Errorf("[%s] %s: unexpected mapping type: %s", name, evcodeRaw, mappingType)

--- a/internal/pkg/midi/device/events.go
+++ b/internal/pkg/midi/device/events.go
@@ -125,20 +125,31 @@ func (d *Device) handleABSEvent(ie *input.InputEvent) {
 		canBeNegative = true
 	}
 
+	// Normalize Value
+	if ie.Event.Value < 0 {
+		value = float64(ie.Event.Value) / math.Abs(float64(min))
+	} else {
+		value = float64(ie.Event.Value) / math.Abs(float64(max))
+	}
+
+	// Put it always between -1.0 and 1.0 so we can deadzone the center
+	if analog.DeadzoneAtCenter {
+		value = value * 2 - 1.0
+		canBeNegative = true
+	}
+
 	deadzone, ok := d.config.Deadzone.Deadzones[ie.Event.Code]
 	if !ok {
 		deadzone = d.config.Deadzone.Default
 	}
-
-	if ie.Event.Value < 0 {
-		value = float64(ie.Event.Value) / math.Abs(float64(min))
+  
+	if value < 0 {
 		if value > -deadzone {
 			value = 0
 		} else {
 			value = (value + deadzone) * (1.0 / (1.0 - deadzone))
 		}
 	} else {
-		value = float64(ie.Event.Value) / math.Abs(float64(max))
 		if value < deadzone {
 			value = 0
 		} else {


### PR DESCRIPTION
Hello!
I made a change that allowed to set the deadzone at the center of the axis, instead of at the 0% mark.

The PS3 controller, for example, sends an unsigned value, so the deadzone only activates on the bottom of the range.
In toml, the config would be:
    ABS_X = { type = "cc", cc = 0 , deadzone_at_center = true }
Or omit it to keep the current behaviour, to not break existing configs

Also, in monitor.go it didn't monitor the file if the suffix was "toml" 👀

Hope this helps!